### PR TITLE
fix: recover swap in free disk script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,12 @@ jobs:
       - name: "Update APT sources"
         run: |
           sudo apt update
-
+ 
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 8
+ 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
           haskell: true
           large-packages: true
           docker-images: true
-          swap-storage: true
+          swap-storage: false
 
       - uses: actions/checkout@v3
       - name: "Install Deps"


### PR DESCRIPTION
clear swap-storage may cause BTF error,
somtimes the reason is out of memory,
so not free the swap space.

log:
FAILED: load BTF from vmlinux: Unknown error -22make[3]: *** [Makefile:1278: vmlinux] Error 255

link:https://github.com/deepin-community/deepin-riscv-kernel/actions/runs/5709859515/job/15469235995